### PR TITLE
Remove the comment because the rules fail with it

### DIFF
--- a/iptables/init.sls
+++ b/iptables/init.sls
@@ -65,7 +65,6 @@
           - source: {{ ip }}
           - dport: {{ service_name }}
           - proto: tcp
-          - comment: {{service_name}}_allow_{{ip}}
           - save: True
     {%- endfor %}
 

--- a/iptables/service.sls
+++ b/iptables/service.sls
@@ -29,7 +29,6 @@
     - source: {{ ip }}
     - dport: {{ service_name }}
     - proto: tcp
-    - comment: {{sls_params.parent}}_{{service_name}}_allow_{{ip}}
     - save: True
     {%- endfor %}
 


### PR DESCRIPTION
The --comment option should be preceded by "-m comment"
and it is not, so the rules fail on iptables starting with
version 1.4.14
