### PR TITLE
Support for IPv6 (Issue 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ extend:
 Using iptables.nat
 ==================
 
-You can use nat for interface.
+You can use nat for interface. This is supported for IPv4 alone. IPv6 deployments should not use NAT.
 
 ```
   #Support nat
@@ -113,3 +113,31 @@ You can use nat for interface.
         '192.168.18.0/24':
           - 10.20.0.2
 ```
+
+IPv6 Support
+============
+
+This formula supports IPv6 as long as it is activated with the option:
+
+```
+firewall:
+  ipv6: True
+```
+
+Services and whitelists are supported under the sections `services_ipv6` and `whitelist_ipv6`, as below:
+
+```
+  services_ipv6:
+    ssh:
+      block_nomatch: False
+      ips_allow:
+        - 2a02:2028:773:d01:10a5:f34f:e7ff:f55b/64
+        - 2a02:2028:773:d01:1814:28ef:e91b:70b8/64
+
+  whitelist_ipv6:
+    networks:
+      ips_allow:
+        - 2a02:2028:773:d01:1814:28ef:e91b:70b8/64
+```
+
+These sections are only processed if the ipv6 support is activated.

--- a/iptables/init.sls
+++ b/iptables/init.sls
@@ -284,4 +284,20 @@
     {%- endfor %}
   {%- endfor %}
 
+  # Generate rules for whitelisting IP classes with ipv6
+  {%- if ipv6 %} 
+  {%- for service_name, service_details in firewall.get('whitelist_ipv6', {}).items() %}
+    {%- for ip in service_details.get('ips_allow', []) %}
+      iptables_{{service_name}}_allow_{{ip}}_ipv6:
+        iptables.append:
+           - table: filter
+           - chain: INPUT
+           - jump: ACCEPT
+           - source: {{ ip }}
+           - family: ipv6
+           - save: True
+    {%- endfor %}
+  {%- endfor %}
+  {%- endif %}
+
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,7 @@ firewall:
   install: True
   enabled: True
   strict: True
+  ipv6: True
   services:
     ssh:
       block_nomatch: False
@@ -19,7 +20,27 @@ firewall:
         - udp
         - tcp
       interfaces:
-        - eht0
+        - eth0
+  services_ipv6:
+    ssh:
+      block_nomatch: False
+      ips_allow:
+        - 2a02:2028:773:d01:10a5:f34f:e7ff:f55b/64
+        - 2a02:2028:773:d01:1814:28ef:e91b:70b8/64
+    http:
+      block_nomatch: False
+      protos:
+        - udp
+        - tcp
+    snmp:
+      block_nomatch: False
+      protos:
+        - udp
+        - tcp
+      interfaces:
+        - eth0
+
+
 
   whitelist:
     networks:

--- a/pillar.example
+++ b/pillar.example
@@ -40,14 +40,17 @@ firewall:
       interfaces:
         - eth0
 
-
-
   whitelist:
     networks:
       ips_allow:
         - 10.0.0.0/8
 
-  #Suppport nat
+  whitelist_ipv6:
+    networks:
+      ips_allow:
+        - 2a02:2028:773:d01:1814:28ef:e91b:70b8/64
+
+  #Support nat (ipv4 only)
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 10.20.0.2 -j MASQUERADE
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 172.31.0.2 -j MASQUERADE
   nat:


### PR DESCRIPTION
This PR intends to fix https://github.com/saltstack-formulas/iptables-formula/issues/11. 

To allow the flexibility of defining different rules for IPv4 and IPv6 services I've added different sections for IPv6 `services` and `whitelists`.

Please have a look and let me know whether it looks good!