### PR TITLE
iptables: When no ips_allow are specified assume all IPs are allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Notes:
  * Strict mode means: Deny **everything** except explicitly allowed (use with care!)
  * block_nomatch: With non-strict mode adds in a "REJECT" rule below the accept rules, otherwise other traffic to that service is still allowed. Can be defined per-service or globally, defaults to False.
  * Service names can be either port numbers or service names (e.g. ssh, zabbix-agent, http) and are available for viewing/configuring in `/etc/services`
+ * If no `ips_allow` stanza is provided for any particular ruleset instead of not adding the rule the addition itself is scoped globally (0.0.0.0/0)
 
 Using iptables.service
 ======================

--- a/iptables/init.sls
+++ b/iptables/init.sls
@@ -63,7 +63,7 @@
     {% endif %}
 
     # Allow rules for ips/subnets
-    {%- for ip in service_details.get('ips_allow', []) %}
+    {%- for ip in service_details.get('ips_allow', ['0.0.0.0/0']) %}
       {%- if interfaces == '' %}
         {%- for proto in protos %}
       iptables_{{service_name}}_allow_{{ip}}_{{proto}}:


### PR DESCRIPTION
When no `ips_allow` stanzas are provided for a particular ruleset no rule actually propagates in these circumstances; with the following pillar stanza one would presume that a global `ACCEPT` would propagate the following rule set:


Pillar:
```
firewall:
  enabled: true
  services:
    ssh:
      block_nomatch: False
      protos:
        - tcp
```


IPTables ruslet:
```
root@custom-bento-debian-9:~# iptables-save
# Generated by iptables-save v1.6.0 on Fri Dec  7 19:33:08 2018
*filter
:INPUT DROP [0:0]
:FORWARD ACCEPT [0:0]
:OUTPUT ACCEPT [150:16911]
-A INPUT -s 127.0.0.1/32 -j ACCEPT
-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
COMMIT
# Completed on Fri Dec  7 19:33:08 2018
```