### PR TITLE
Add support to manage individual tables, with tests and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
     - INSTANCE: default-ubuntu-1804
     - INSTANCE: default-centos-7
     - INSTANCE: default-fedora-27
+    - INSTANCE: tables-debian-9
+    - INSTANCE: tables-ubuntu-1804
+    - INSTANCE: tables-centos-7
+    - INSTANCE: tables-fedora-27
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 iptables formula
 ================
 
+0.4.0 (2019-03-25)
+
+- Add state to manage tables via pillars
+
 0.3.0 (2018-12-28)
 
 - Update formula to use defaults.yml and map.jinja

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gem 'kitchen-docker', '>= 2.9'
-gem 'kitchen-salt', '>= 0.5.0'
+gem 'kitchen-salt', '>= 0.6.0'
 gem 'kitchen-inspec', '>= 1.1'
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'test-kitchen', '>=1.20'
-gem 'kitchen-docker'
-gem 'kitchen-salt', '>=0.4.0'
-gem 'kitchen-inspec'
-
+gem 'kitchen-docker', '>= 2.9'
+gem 'kitchen-salt', '>= 0.5.0'
+gem 'kitchen-inspec', '>= 1.1'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Pull requests are welcome for other platforms (or other improvements ofcourse!)
 Usage
 =====
 
+## Configure the firewall using `services`
+
 All the configuration for the firewall is done via the pillar (see the pillar.example file).
 
 Enable globally:
@@ -22,6 +24,7 @@ firewall:
   enabled: True
   install: True  
   strict: True
+  use_tables: False
 ```
 
 Allow SSH:
@@ -126,3 +129,17 @@ You can use nat for interface.
         '192.168.18.0/24':
           - 10.20.0.2
 ```
+## Configure the firewall using `tables`
+
+The state `iptables.tables` let's you configure your firewall iterating over pillars
+defining rules to add to the different tables (filter, mangle, nat) instead of using services.
+
+Just set to enable the 'tables' mode:
+
+```yaml
+firewall:
+  use_tables: True
+```
+
+Please check the `pillar.tables.example` to see how to define your rules.
+

--- a/iptables/defaults.yaml
+++ b/iptables/defaults.yaml
@@ -4,6 +4,48 @@ firewall:
   enabled: false
   install: false
   strict: false
+  # If use_mode is false, we use the services-based default behaviour
+  use_tables: false
   block_nomatch: false
   pkgs:
     - iptables
+
+  filter:
+    INPUT:
+      policy: ACCEPT
+      rules: {}
+    FORWARD:
+      policy: ACCEPT
+      rules: {}
+    OUTPUT:
+      policy: ACCEPT
+      rules: {}
+
+  nat:
+    PREROUTING:
+      policy: ACCEPT
+      rules: {}
+    INPUT:
+      policy: ACCEPT
+      rules: {}
+    OUTPUT:
+      policy: ACCEPT
+      rules: {}
+    POSTROUTING:
+      policy: ACCEPT
+      rules: {}
+
+  mangle:
+    PREROUTING:
+      policy: ACCEPT
+      rules: {}
+    INPUT:
+      policy: ACCEPT
+      rules: {}
+    OUTPUT:
+      policy: ACCEPT
+      rules: {}
+    POSTROUTING:
+      policy: ACCEPT
+      rules: {}
+

--- a/iptables/defaults.yaml
+++ b/iptables/defaults.yaml
@@ -4,7 +4,7 @@ firewall:
   enabled: false
   install: false
   strict: false
-  # If use_mode is false, we use the services-based default behaviour
+  # If use_tables is false, we use the services-based default behaviour
   use_tables: false
   block_nomatch: false
   pkgs:

--- a/iptables/init.sls
+++ b/iptables/init.sls
@@ -4,6 +4,7 @@
 # Firewall management module
 {% from "iptables/map.jinja" import firewall with context %}
 {% set install = firewall.install %}
+{% set use_tables = firewall.use_tables %}
 {% set strict_mode = firewall.strict %}
 {% set global_block_nomatch = firewall.block_nomatch %}
 {% set packages = firewall.pkgs %}
@@ -51,6 +52,7 @@
             - iptables: iptables_allow_established
     {%- endif %}
 
+  {% if not use_tables %}
   # Generate ipsets for all services that we have information about
   {%- for service_name, service_details in firewall.get('services', {}).items() %}
     {% set block_nomatch = service_details.get('block_nomatch', False) %}
@@ -151,6 +153,8 @@
       {%- endfor %}
     {%- endfor %}
   {%- endfor %}
+
+  {% endif %}
 
   # Generate rules for whitelisting IP classes
   {%- for service_name, service_details in firewall.get('whitelist', {}).items() %}

--- a/iptables/map.jinja
+++ b/iptables/map.jinja
@@ -10,6 +10,6 @@
         osfamilymap,
         grain='os_family',
         merge = salt['pillar.get']('firewall', {})
-    ),
+        ),
     base='firewall')
 %}

--- a/iptables/tables.sls
+++ b/iptables/tables.sls
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "iptables/map.jinja" import firewall with context %}
+
+{% for t in ['filter','nat','mangle'] %}
+  {% for cn, cv in firewall.get(t).items() %}
+    {% set pol = cv.policy | default('ACCEPT') %}
+    {% set rules = cv.rules | default({}) %}
+
+    chain_present_{{ t }}_{{ cn }}:
+      iptables.chain_present:
+        - table: {{ t }}
+        - name: {{ cn }}
+
+    {% for rn, rv in rules.items() %}
+    rule_{{ t }}_{{ cn }}_{{ rn }}:
+      iptables.append:
+        - table: {{ t }}
+        - chain: {{ cn }}
+        {% for k,v in rv.items() %}
+        - {{ k }}: '{{ v }}'
+        {% endfor %}
+        - save: true
+        - require:
+            - iptables: chain_present_{{ t }}_{{ cn }}
+    {% endfor %}
+
+    {% if cn in ['INPUT','OUTPUT','FORWARD','PREROUTING','POSTROUTING'] %}
+    # Set policies
+    policy_{{ t }}_{{ cn }}_{{ pol }}:
+      iptables.set_policy:
+        - table: {{ t }}
+        - chain: {{ cn }}
+        - policy: {{ pol }}
+        - save: true
+    {% endif %}
+  {% endfor %}
+{% endfor %}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -35,7 +35,7 @@ provisioner:
   salt_copy_filter:
     - .kitchen
     - .git
-  pillars-from-files:
+  pillars_from_files:
     iptables.sls: pillar.example
   pillars:
     top.sls:
@@ -59,3 +59,22 @@ verifier:
 
 suites:
   - name: default
+  - name: tables
+    provisioner:
+      pillars_from_files:
+        tables.sls: pillar.tables.example
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - tables
+    
+      state_top:
+        base:
+          '*':
+            - iptables
+            - iptables.tables
+
+    verifier:
+      inspec_tests:
+        - path: test/integration/tables

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,8 @@ firewall:
   install: True
   enabled: True
   strict: True
+  ## To manage the firewall writing rules instead of services, check
+  ## the `pillar.tables.example` for examples
   services:
     ssh:
       block_nomatch: True

--- a/pillar.tables.example
+++ b/pillar.tables.example
@@ -1,0 +1,42 @@
+# In this example we iterate over tables (filter, nat, mangle) and
+# adds the desired entries 
+firewall:
+  install: True
+  enabled: True
+  strict: True
+
+  # To use tables, leave services undefined and set this to true
+  use_tables: True
+
+  whitelist:
+    networks:
+      ips_allow:
+        - 10.10.10.0/24
+
+  filter:
+    INPUT:
+      rules:
+        test_rule:
+          source: 172.22.172.0/24
+          protocol: tcp
+          match: multiport
+          dports: 80,443
+          jump: ACCEPT
+    CUSTOM_CHAIN:
+      rules:
+        some_custom_rule:
+          source: 192.168.12.0/23
+          protocol: tcp
+          dport: 2222
+          jump: REJECT
+
+  #Suppport nat
+  # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 10.20.0.2 -j MASQUERADE
+  # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 172.31.0.2 -j MASQUERADE
+  nat:
+    POSTROUTING:
+      rules:
+        masquerade:
+          source: '192.168.18.0/24'
+          destination: '10.20.0.2'
+          jump: MASQUERADE

--- a/test/integration/tables/rules_spec.rb
+++ b/test/integration/tables/rules_spec.rb
@@ -1,0 +1,13 @@
+control 'Rules' do
+  describe iptables do
+    it { should have_rule('-A INPUT -s 127.0.0.1/32 -j ACCEPT') }
+    it { should have_rule('-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT') }
+    it { should have_rule('-A INPUT -s 10.10.10.0/24 -j ACCEPT') }
+
+    it { should have_rule('-A INPUT -s 172.22.172.0/24 -p tcp -m multiport --dports 80,443 -j ACCEPT') }
+    it { should have_rule('-A CUSTOM_CHAIN -s 192.168.12.0/23 -p tcp -m tcp --dport 2222 -j REJECT --reject-with icmp-port-unreachable') }
+  end
+  describe iptables(table:'nat') do
+    it { should have_rule('-A POSTROUTING -s 192.168.18.0/24 -d 10.20.0.2/32 -j MASQUERADE') }
+  end
+end


### PR DESCRIPTION
Add the possibility to manage iptables' tables, iterating over pillars.

Added tests for the new state file.

Updated the `Gemfile` to get tests passing ( I think this should also fix the failures in #32)
