### PR TITLE
ci(kitchen): add remaining platforms from `template-formula`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,19 +26,24 @@ services:
 #       Ref: https://github.com/saltstack-formulas/template-formula/issues/121
 env:
   matrix:
-    - INSTANCE: default-debian-9-2019-2-py3
-    # - INSTANCE: default-ubuntu-1804-2019-2-py3
+    - INSTANCE: default-debian-9-develop-py3
+    # - INSTANCE: default-ubuntu-1804-develop-py3
+    # - INSTANCE: default-centos-7-develop-py3
+    # - INSTANCE: default-fedora-29-develop-py3
+    # - INSTANCE: default-opensuse-leap-15-develop-py3
+    # - INSTANCE: default-debian-9-2019-2-py3
+    - INSTANCE: default-ubuntu-1804-2019-2-py3
     - INSTANCE: default-centos-7-2019-2-py3
-    - INSTANCE: default-fedora-29-2019-2-py3
+    # - INSTANCE: default-fedora-29-2019-2-py3
     # - INSTANCE: default-opensuse-leap-15-2019-2-py3
     # - INSTANCE: default-debian-9-2018-3-py2
-    - INSTANCE: default-ubuntu-1604-2018-3-py2
+    # - INSTANCE: default-ubuntu-1604-2018-3-py2
     # - INSTANCE: default-centos-7-2018-3-py2
-    # - INSTANCE: default-fedora-29-2018-3-py2
+    - INSTANCE: default-fedora-29-2018-3-py2
     # TODO: Use this when fixed instead of `opensuse-leap-42`
     # Ref: https://github.com/netmanagers/salt-image-builder/issues/2
     # - INSTANCE: default-opensuse-leap-15-2018-3-py2
-    # - INSTANCE: default-opensuse-leap-42-2018-3-py2
+    - INSTANCE: default-opensuse-leap-42-2018-3-py2
     # - INSTANCE: default-debian-8-2017-7-py2
     # - INSTANCE: tables-ubuntu-1604-2017-7-py2
     # TODO: Enable after improving the formula to work with other than `systemd`

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,6 +11,40 @@ driver:
 # Make sure the platforms listed below match up with
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
+  ## SALT `develop`
+  - name: debian-9-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:debian-9
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: ubuntu-1804-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:ubuntu-18.04
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: centos-7-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:centos-7
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: fedora-29-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:fedora-29
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: opensuse-leap-15-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:opensuse-leap-15
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+      run_command: /usr/lib/systemd/systemd
+
+  ## SALT 2019.2
   - name: debian-9-2019-2-py3
     driver:
       image: netmanagers/salt-2019.2-py3:debian-9
@@ -27,9 +61,46 @@ platforms:
     driver:
       image: netmanagers/salt-2019.2-py3:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+
+  ## SALT 2018.3
+  - name: debian-9-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:debian-9
   - name: ubuntu-1604-2018-3-py2
     driver:
       image: netmanagers/salt-2018.3-py2:ubuntu-16.04
+  - name: centos-7-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:centos-7
+  - name: fedora-29-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:fedora-29
+  # TODO: Use this when fixed instead of `opensuse-leap-42`
+  # Ref: https://github.com/netmanagers/salt-image-builder/issues/2
+  # - name: opensuse-leap-15-2018-3-py2
+  #   driver:
+  #     image: netmanagers/salt-2018.3-py2:opensuse-leap-15
+  #     run_command: /usr/lib/systemd/systemd
+  - name: opensuse-leap-42-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:opensuse-leap-42
+      run_command: /usr/lib/systemd/systemd
+
+  ## SALT 2017.7
+  - name: debian-8-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:debian-8
+  - name: ubuntu-1604-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:ubuntu-16.04
+  # TODO: Modify the formula to work for non-`systemd` platforms
+  - name: centos-6-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:centos-6
+      run_command: /sbin/init
+  - name: fedora-28-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:fedora-28
   - name: opensuse-leap-42-2017-7-py2
     driver:
       image: netmanagers/salt-2017.7-py2:opensuse-leap-42


### PR DESCRIPTION
@javierbertoli So continuing from here: https://github.com/saltstack-formulas/iptables-formula/pull/37#issuecomment-500993728.

I haven't done it here yet but I'd like to also consider changing to the "tree"-style matrix that we have.  I've run this in Travis, so would you care to select from here?

* https://travis-ci.com/myii/iptables-formula/builds/115154624