### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -65,16 +65,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.pillar.sls test/salt/pillar/tables.pillar.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  key-duplicates:
+    ignore: |
+      pillar.example
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/iptables/defaults.yaml
+++ b/iptables/defaults.yaml
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
+---
 firewall:
   enabled: false
   install: false
@@ -47,4 +48,3 @@ firewall:
     POSTROUTING:
       policy: ACCEPT
       rules: {}
-

--- a/iptables/osfamilymap.yaml
+++ b/iptables/osfamilymap.yaml
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
+---
 Debian:
   pkgs:
     - iptables

--- a/pillar.example
+++ b/pillar.example
@@ -1,22 +1,25 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 firewall:
-  install: True
-  enabled: True
-  strict: True
-  ipv6: True
+  install: true
+  enabled: true
+  strict: true
+  ipv6: true
   services:
     ssh:
-      block_nomatch: True
+      block_nomatch: true
       ips_allow:
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16
     http:
-      block_nomatch: False
+      block_nomatch: false
       protos:
         - udp
         - tcp
     snmp:
-      block_nomatch: False
+      block_nomatch: false
       protos:
         - udp
         - tcp
@@ -25,17 +28,17 @@ firewall:
 
   services_ipv6:
     ssh:
-      block_nomatch: False
+      block_nomatch: false
       ips_allow:
         - 2a02:2028:773:d01:10a5:f34f:e7ff:f55b/64
         - 2a02:2028:773:d01:1814:28ef:e91b:70b8/64
     http:
-      block_nomatch: False
+      block_nomatch: false
       protos:
         - udp
         - tcp
     snmp:
-      block_nomatch: False
+      block_nomatch: false
       protos:
         - udp
         - tcp
@@ -52,9 +55,11 @@ firewall:
       ips_allow:
         - 2a02:2028:773:d01:1814:28ef:e91b:70b8/64
 
-  #Support nat (ipv4 only)
+  # yamllint disable rule:line-length
+  # Support nat (ipv4 only)
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 10.20.0.2 -j MASQUERADE
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 172.31.0.2 -j MASQUERADE
+  # yamllint enable rule:line-length
   nat:
     eth0:
       rules:
@@ -64,14 +69,14 @@ firewall:
 ### Using the tables.sls state
 
 # In this example we iterate over tables (filter, nat, mangle) and
-# adds the desired entries 
+# adds the desired entries
 firewall:
-  install: True
-  enabled: True
-  strict: True
+  install: true
+  enabled: true
+  strict: true
 
   # To use tables, leave services undefined and set this to true
-  use_tables: True
+  use_tables: true
 
   filter:
     INPUT:

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: iptables formula
 maintainer: SaltStack Formulas

--- a/test/integration/tables/inspec.yml
+++ b/test/integration/tables/inspec.yml
@@ -1,7 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: tables
 title: iptables formula
 maintainer: SaltStack Formulas
 license: Apache-2.0
+# yamllint disable-line rule:line-length
 summary: Verify that iptables is installed and configured using tables defined in pillars
 supports:
   - platform-name: debian

--- a/test/salt/pillar/default.pillar.sls
+++ b/test/salt/pillar/default.pillar.sls
@@ -1,24 +1,27 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 firewall:
-  install: True
-  enabled: True
-  strict: True
-  ipv6: False
+  install: true
+  enabled: true
+  strict: true
+  ipv6: false
   ## To manage the firewall writing rules instead of services, check
   ## the `pillar.tables.example` for examples
   services:
     ssh:
-      block_nomatch: True
+      block_nomatch: true
       ips_allow:
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16
     http:
-      block_nomatch: False
+      block_nomatch: false
       protos:
         - udp
         - tcp
     snmp:
-      block_nomatch: False
+      block_nomatch: false
       protos:
         - udp
         - tcp
@@ -30,9 +33,11 @@ firewall:
       ips_allow:
         - 10.0.0.0/8
 
-  #Support nat (ipv4 only)
+  # yamllint disable rule:line-length
+  # Support nat (ipv4 only)
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 10.20.0.2 -j MASQUERADE
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 172.31.0.2 -j MASQUERADE
+  # yamllint enable rule:line-length
   nat:
     eth0:
       rules:

--- a/test/salt/pillar/tables.pillar.sls
+++ b/test/salt/pillar/tables.pillar.sls
@@ -1,12 +1,15 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # In this example we iterate over tables (filter, nat, mangle) and
-# adds the desired entries 
+# adds the desired entries
 firewall:
-  install: True
-  enabled: True
-  strict: True
+  install: true
+  enabled: true
+  strict: true
 
   # To use tables, leave services undefined and set this to true
-  use_tables: True
+  use_tables: true
 
   whitelist:
     networks:
@@ -34,9 +37,11 @@ firewall:
           dport: 2222
           jump: REJECT
 
-  #Suppport nat
+  # yamllint disable rule:line-length
+  # Suppport nat
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 10.20.0.2 -j MASQUERADE
   # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.18.0/24 -d 172.31.0.2 -j MASQUERADE
+  # yamllint enable rule:line-length
   nat:
     POSTROUTING:
       rules:


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix (or ignore) errors shown below:

```bash
iptables-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./iptables/defaults.yaml
  3:1       warning  missing document start "---"  (document-start)
  50:1      error    too many blank lines (1 > 0)  (empty-lines)

./iptables/osfamilymap.yaml
  3:1       warning  missing document start "---"  (document-start)

./test/integration/tables/inspec.yml
  8:89      error    line too long (89 > 88 characters)  (line-length)

pillar.example
  1:1       warning  missing document start "---"  (document-start)
  2:12      warning  truthy value should be one of [false, true]  (truthy)
  3:12      warning  truthy value should be one of [false, true]  (truthy)
  4:11      warning  truthy value should be one of [false, true]  (truthy)
  5:9       warning  truthy value should be one of [false, true]  (truthy)
  8:22      warning  truthy value should be one of [false, true]  (truthy)
  14:22     warning  truthy value should be one of [false, true]  (truthy)
  19:22     warning  truthy value should be one of [false, true]  (truthy)
  28:22     warning  truthy value should be one of [false, true]  (truthy)
  33:22     warning  truthy value should be one of [false, true]  (truthy)
  38:22     warning  truthy value should be one of [false, true]  (truthy)
  55:4      warning  missing starting space in comment  (comments)
  57:89     error    line too long (89 > 88 characters)  (line-length)
  67:27     error    trailing spaces  (trailing-spaces)
  68:1      error    duplication of key "firewall" in mapping  (key-duplicates)
  69:12     warning  truthy value should be one of [false, true]  (truthy)
  70:12     warning  truthy value should be one of [false, true]  (truthy)
  71:11     warning  truthy value should be one of [false, true]  (truthy)
  74:15     warning  truthy value should be one of [false, true]  (truthy)

test/salt/pillar/default.pillar.sls
  1:1       warning  missing document start "---"  (document-start)
  2:12      warning  truthy value should be one of [false, true]  (truthy)
  3:12      warning  truthy value should be one of [false, true]  (truthy)
  4:11      warning  truthy value should be one of [false, true]  (truthy)
  5:9       warning  truthy value should be one of [false, true]  (truthy)
  10:22     warning  truthy value should be one of [false, true]  (truthy)
  16:22     warning  truthy value should be one of [false, true]  (truthy)
  21:22     warning  truthy value should be one of [false, true]  (truthy)
  33:4      warning  missing starting space in comment  (comments)
  35:89     error    line too long (89 > 88 characters)  (line-length)

test/salt/pillar/tables.pillar.sls
  2:27      error    trailing spaces  (trailing-spaces)
  3:1       warning  missing document start "---"  (document-start)
  4:12      warning  truthy value should be one of [false, true]  (truthy)
  5:12      warning  truthy value should be one of [false, true]  (truthy)
  6:11      warning  truthy value should be one of [false, true]  (truthy)
  9:15      warning  truthy value should be one of [false, true]  (truthy)
  37:4      warning  missing starting space in comment  (comments)
  39:89     error    line too long (89 > 88 characters)  (line-length)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.