### PR TITLE
remove dictsort from iptables.tables

### DIFF
--- a/iptables/tables.sls
+++ b/iptables/tables.sls
@@ -14,16 +14,16 @@ chain_present_{{ t }}_{{ cn }}:
   {%- for cn, cv in firewall.get(t).items() %}
     {%- set pol = cv.policy | default('ACCEPT') %}
     {%- set rules = cv.rules | default({}) %}
-    {%- for rn, rv in rules|dictsort %}
-rule_{{ t }}_{{ cn }}_{{ rn }}:
-      {%- if rv['position'] is defined %}
+    {%- for r in rules %}
+rule_{{ t }}_{{ cn }}_{{ r }}:
+      {%- if rules[r]['position'] is defined %}
   iptables.insert:
       {%- else %}
   iptables.append:
       {%- endif %}
     - table: {{ t }}
     - chain: {{ cn }}
-        {%- for k,v in rv.items() %}
+        {%- for k,v in rules[r].items() %}
     - {{ k }}: '{{ v }}'
         {%- endfor %}
     - save: true


### PR DESCRIPTION
This removes the behavior of sorting the rules before execution which is not needed