### PR TITLE
fix(fedora-34): use `iptables-compat` package for installation

### DIFF
--- a/iptables/init.sls
+++ b/iptables/init.sls
@@ -6,7 +6,9 @@
 {%- set install = firewall.install %}
 {%- set strict_mode = firewall.strict %}
 {%- set global_block_nomatch = firewall.block_nomatch %}
-{%- set packages = firewall.pkgs %}
+{#- TODO: Ideally, this Fedora 34 fix should be provided from `osfingermap.yaml` but that isn't available #}
+{#-       Resolve this when the new `map.jinja` is made available for this formula #}
+{%- set packages = ['iptables-compat'] if grains.get('osfinger', '') == 'Fedora-34' else firewall.pkgs %}
 {%- set ipv4 = 'IPv4' %}
 {%- set ipv6 = 'IPv6' %}
 {%- set protocols = [ipv4] %}

--- a/test/integration/default/controls/packages_spec.rb
+++ b/test/integration/default/controls/packages_spec.rb
@@ -2,12 +2,18 @@
 
 common_packages = ['iptables']
 
-case os[:name]
-when 'debian', 'ubuntu'
-  all_packages = common_packages + %w[iptables-persistent netbase]
-else
-  all_packages = common_packages
-end
+all_packages =
+  case platform[:name]
+  when 'debian', 'ubuntu'
+    common_packages + %w[iptables-persistent netbase]
+  else
+    case system.platform[:finger]
+    when 'fedora-34'
+      ['iptables-compat']
+    else
+      common_packages
+    end
+  end
 
 control 'Packages' do
   all_packages.each do |p|


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

* https://bugzilla.redhat.com/show_bug.cgi?id=1953178

Fedora 34 has recently started failing during the weekly CI tests.  Tracking it down, the `iptables` package is no longer installed but the `iptables-compat` package is installed in its place:

```console
[root@35ff65fca7a8 /]# dnf install iptables
Last metadata expiration check: 0:05:49 ago on Wed Jun 16 09:28:13 2021.
Dependencies resolved.
================================================================================================================================================================================
 Package                                            Architecture                         Version                                    Repository                             Size
================================================================================================================================================================================
Installing:
 iptables-compat                                    x86_64                               1.8.7-8.fc34                               updates                                11 k
Upgrading:
 iptables-libs                                      x86_64                               1.8.7-8.fc34                               updates                               402 k
 systemd                                            x86_64                               248.3-1.fc34                               updates                               4.4 M
 systemd-libs                                       x86_64                               248.3-1.fc34                               updates                               593 k
 systemd-pam                                        x86_64                               248.3-1.fc34                               updates                               322 k
 systemd-rpm-macros                                 noarch                               248.3-1.fc34                               updates                                28 k
 systemd-udev                                       x86_64                               248.3-1.fc34                               updates                               1.5 M
Installing dependencies:
 iptables-legacy                                    x86_64                               1.8.7-8.fc34                               updates                                54 k
 iptables-legacy-libs                               x86_64                               1.8.7-8.fc34                               updates                                40 k
 iptables-utils                                     x86_64                               1.8.7-8.fc34                               updates                                43 k
 xkeyboard-config                                   noarch                               2.32-3.fc34                                updates                               789 k
Installing weak dependencies:
 diffutils                                          x86_64                               3.7-8.fc34                                 fedora                                391 k
 libxkbcommon                                       x86_64                               1.3.0-1.fc34                               updates                               144 k
 qrencode-libs                                      x86_64                               4.0.2-7.fc34                               fedora                                 60 k
 systemd-networkd                                   x86_64                               248.3-1.fc34                               updates                               480 k

Transaction Summary
================================================================================================================================================================================
Install  9 Packages
Upgrade  6 Packages
```

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


